### PR TITLE
Added submenu e divider option

### DIFF
--- a/app/scripts/context-menu.js
+++ b/app/scripts/context-menu.js
@@ -7,7 +7,7 @@
  * # contextMenu
  * Custom Context Menu Directive
  */
-angular.module('contextMenuApp')
+angular.module('pastaApp')
     .directive('contextMenu', ['$document', '$window', function ($document, $window) {
         // Runs during compile
         return {
@@ -30,7 +30,6 @@ angular.module('contextMenuApp')
                         bottomLeft: 'context-caret-bottom-left'
                     },
                     menuItems = $attr.menuItems;
-
                 function createContextMenu() {
                     var fragment = document.createDocumentFragment();
 
@@ -38,26 +37,55 @@ angular.module('contextMenuApp')
                         $contextMenuElm = $(contextMenuElm);
                     contextMenuElm.setAttribute('id', 'context-menu');
                     contextMenuElm.setAttribute('class', 'custom-context-menu');
-
-                    $scope[menuItems].forEach(function (_item) {
-                        var li = document.createElement('li');
-                        li.innerHTML = '<a>' + _item.label + '</a>';
-
-                        if (_item.action && _item.active) {
-                            li.addEventListener('click', function () {
-                                if (typeof $scope[_item.action] !== 'function') return false;
-                                $scope[_item.action]($attr);
-                            }, false);
-                        }
-
-                        if (!_item.active) li.setAttribute('class', 'disabled');
-                        fragment.appendChild(li);
-                    });
-
+                    
+                    mountContextMenu($scope[menuItems], fragment);
+                    
                     contextMenuElm.appendChild(fragment);
                     document.body.appendChild(contextMenuElm);
                     contextMenuWidth = $contextMenuElm.outerWidth(true);
                     contextMenuHeight = $contextMenuElm.outerHeight(true);
+                }
+                
+                function mountContextMenu(menuItems, fragment){
+                	menuItems.forEach(function (_item) {
+                    	var li = document.createElement('li');
+	                        
+                        li.innerHTML = '<a>' + _item.label + ' <span class="right-caret"></span></a>';
+                        
+                        if (_item.action && _item.active) {
+                            li.addEventListener('click', function () {
+                                if (typeof $scope[_item.action] !== 'function') return false;
+                                $scope[_item.action]($attr, $scope);
+                            }, false);
+                        }
+                        
+                        if(_item.divider){
+                    		addContextMenuDivider(fragment);
+                    	} 
+                        
+                        if (!_item.active) li.setAttribute('class', 'disabled');
+                        
+                        if(_item.subItems) {
+                        	addSubmenuItems(_item.subItems, li)
+                        }
+                        
+                        fragment.appendChild(li);
+                    });
+                }
+
+                function addSubmenuItems(subItems, parentLi){
+                    parentLi.setAttribute('class', 'dropdown-submenu')
+                    var ul = document.createElement('ul');
+                    parentLi.setAttribute("class", "dropdown-menu")
+                    mountContextMenu(subItems, ul)
+                        	
+                    parentLi.appendChild(ul)
+                }
+                
+                function addContextMenuDivider(fragment){
+                	var divider = document.createElement('li');
+            		divider.className = 'divider'
+            		fragment.appendChild(divider);
                 }
 
                 /**

--- a/app/scripts/context-menu.js
+++ b/app/scripts/context-menu.js
@@ -7,7 +7,7 @@
  * # contextMenu
  * Custom Context Menu Directive
  */
-angular.module('pastaApp')
+angular.module('contextMenuApp')
     .directive('contextMenu', ['$document', '$window', function ($document, $window) {
         // Runs during compile
         return {

--- a/app/styles/style.css
+++ b/app/styles/style.css
@@ -1,0 +1,50 @@
+/*
+* http://bootsnipp.com/snippets/featured/multi-level-dropdown-menu-bs3
+*/
+.dropdown-submenu {
+    position: relative;
+}
+
+.dropdown-submenu>.dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: -6px;
+    margin-left: -1px;
+    -webkit-border-radius: 0 6px 6px 6px;
+    -moz-border-radius: 0 6px 6px;
+    border-radius: 0 6px 6px 6px;
+}
+
+.dropdown-submenu:hover>.dropdown-menu {
+    display: block;
+}
+
+.dropdown-submenu>a:after {
+    display: block;
+    content: " ";
+    float: right;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 5px 0 5px 5px;
+    border-left-color: #ccc;
+    margin-top: 5px;
+    margin-right: -10px;
+}
+
+.dropdown-submenu:hover>a:after {
+    border-left-color: #fff;
+}
+
+.dropdown-submenu.pull-left {
+    float: none;
+}
+
+.dropdown-submenu.pull-left>.dropdown-menu {
+    left: -100%;
+    margin-left: 10px;
+    -webkit-border-radius: 6px 0 6px 6px;
+    -moz-border-radius: 6px 0 6px 6px;
+    border-radius: 6px 0 6px 6px;
+}


### PR DESCRIPTION
 - Created a submenu and divider option that you can pass on your menu declaration. For example:

```
    $scope.menusDefault = {label: 'Menu item',
                action: '',
                subItems:[{label: 'Sub menu item',
                           action: 'myAction',
                           active: true, divider: true},
                }
```

- If you set divider as true you will create a divider over the menu item.